### PR TITLE
Ability to customize output window

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,7 +47,8 @@ dependencies {
     compile libraries.supportDesign
     compile 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
 
-    debugCompile 'com.github.tatocaster.BuildNumberOverlay:buildnumberoverlaylibrary:1.0.1'
+    //debugCompile 'com.github.tatocaster.BuildNumberOverlay:buildnumberoverlaylibrary:1.0.1'
+    debugCompile project(':buildnumberoverlaylibrary') //compile it locally
     releaseCompile 'com.github.tatocaster.BuildNumberOverlay:buildnumberoverlaylibrary-no-op:1.0.1'
 
     debugCompile libraries.leakCanary

--- a/app/src/main/java/me/tatocaster/buildversionoverlay/MyApp.java
+++ b/app/src/main/java/me/tatocaster/buildversionoverlay/MyApp.java
@@ -1,6 +1,7 @@
 package me.tatocaster.buildversionoverlay;
 
 import android.app.Application;
+import android.graphics.Color;
 
 import me.tatocaster.buildnumberoverlaylibrary.NumberOverlay;
 
@@ -14,6 +15,6 @@ public class MyApp extends Application {
         super.onCreate();
 
         // initialize build number overlay
-        NumberOverlay.initialize(this);
+        NumberOverlay.initialize(this, Color.BLUE, Color.RED);
     }
 }

--- a/app/src/main/java/me/tatocaster/buildversionoverlay/MyApp.java
+++ b/app/src/main/java/me/tatocaster/buildversionoverlay/MyApp.java
@@ -15,7 +15,7 @@ public class MyApp extends Application {
         super.onCreate();
 
         // initialize build number overlay like this
-        NumberOverlay.initialize(this, Color.GREEN, Color.WHITE);
+        NumberOverlay.initialize(this, Color.GRAY, Color.BLACK);
         // or like this
         /*NumberOverlay.initialize(this, 200, 100); */
         // or even like this

--- a/app/src/main/java/me/tatocaster/buildversionoverlay/MyApp.java
+++ b/app/src/main/java/me/tatocaster/buildversionoverlay/MyApp.java
@@ -14,7 +14,11 @@ public class MyApp extends Application {
     public void onCreate() {
         super.onCreate();
 
-        // initialize build number overlay
-        NumberOverlay.initialize(this, Color.BLUE, Color.RED);
+        // initialize build number overlay like this
+        NumberOverlay.initialize(this, Color.GREEN, Color.WHITE);
+        // or like this
+        /*NumberOverlay.initialize(this, 200, 100); */
+        // or even like this
+        /* NumberOverlay.initialize(this, Color.GREEN, Color.WHITE, 200, 100); */
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0-beta2'
+        classpath 'com.android.tools.build:gradle:2.3.1'
         // jitpack
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
 

--- a/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/AccessPermissionActivity.java
+++ b/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/AccessPermissionActivity.java
@@ -22,10 +22,13 @@ public class AccessPermissionActivity extends AppCompatActivity {
 
     private static final int PERMISSION_REQUEST_CODE = 9991;
 
+    private static int[] customsPassingToService = null;
+
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
+        Intent intent = getIntent();
+        customsPassingToService = intent.getExtras().getIntArray("customizations");
         if (isSystemAlertPermissionGranted(this))
             startOverlayService();
         else
@@ -36,8 +39,12 @@ public class AccessPermissionActivity extends AppCompatActivity {
      * start the service
      */
     private void startOverlayService() {
-        if (!Utils.isOverlayingServiceIsRunning(this, OverlayService.class))
-            startService(new Intent(AccessPermissionActivity.this, OverlayService.class));
+
+        if (!Utils.isOverlayingServiceIsRunning(this, OverlayService.class)) {
+            Intent intent = new Intent(AccessPermissionActivity.this, OverlayService.class);
+            intent.putExtra("customizations", customsPassingToService);
+            startService(intent);
+        }
     }
 
     /**

--- a/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/AccessPermissionActivity.java
+++ b/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/AccessPermissionActivity.java
@@ -12,6 +12,8 @@ import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v7.app.AppCompatActivity;
 
+import java.util.HashMap;
+
 import me.tatocaster.buildnumberoverlaylibrary.utils.Utils;
 
 /**
@@ -22,13 +24,13 @@ public class AccessPermissionActivity extends AppCompatActivity {
 
     private static final int PERMISSION_REQUEST_CODE = 9991;
 
-    private static int[] customsPassingToService = null;
+    private static HashMap customsPassingToService = null;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         Intent intent = getIntent();
-        customsPassingToService = intent.getExtras().getIntArray("customizations");
+        customsPassingToService = (HashMap)intent.getExtras().getSerializable("customizations");
         if (isSystemAlertPermissionGranted(this))
             startOverlayService();
         else

--- a/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/NumberOverlay.java
+++ b/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/NumberOverlay.java
@@ -34,7 +34,7 @@ public class NumberOverlay {
      * @param applicationContext The application context
      */
 
-    public static synchronized void initialize(Context applicationContext, final int backgroundColor, final int textColor) {
+    private static synchronized void createInstance(Context applicationContext) {
         if (instance != null || initialized) {
             throw new NumberOverlayException(MULTIPLE_INSTANCE_ERROR_STRING);
         }
@@ -42,8 +42,33 @@ public class NumberOverlay {
         instance = new NumberOverlay();
         NumberOverlay.applicationContext = applicationContext;
 
-        Intent intent = new Intent(getApplicationContext(), AccessPermissionActivity.class);
-        customArray = new int[] {backgroundColor, textColor}; //0% chance of being null. null cannot be passed to primitives
+    }
+    private static Intent getIntent() {
+        return new Intent(getApplicationContext(), AccessPermissionActivity.class);
+    }
+    public static synchronized void initialize(Context applicationContext, final int backgroundColor, final int textColor) {
+        createInstance(applicationContext);
+        Intent intent = getIntent();
+        customArray = new int[] {backgroundColor, textColor};
+        intent.putExtra("customizations", customArray);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        getApplicationContext().startActivity(intent);
+    }
+
+    public static synchronized void initialize(final int CANVAS_HEIGHT, final int CANVAS_WIDTH, Context applicationContext) {
+        createInstance(applicationContext);
+        Intent intent = getIntent();
+        customArray = new int[] {CANVAS_HEIGHT, CANVAS_WIDTH};
+        intent.putExtra("customizations", customArray);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        getApplicationContext().startActivity(intent);
+    }
+
+    public static synchronized void initialize(Context applicationContext, final int backgroundColor, final int textColor,
+                                               final int CANVAS_HEIGHT, final int CANVAS_WIDTH) {
+        createInstance(applicationContext);
+        Intent intent = getIntent();
+        customArray = new int[] {backgroundColor, textColor, CANVAS_HEIGHT, CANVAS_WIDTH};
         intent.putExtra("customizations", customArray);
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         getApplicationContext().startActivity(intent);

--- a/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/NumberOverlay.java
+++ b/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/NumberOverlay.java
@@ -3,20 +3,23 @@ package me.tatocaster.buildnumberoverlaylibrary;
 import android.content.Context;
 import android.content.Intent;
 
+import java.util.HashMap;
+
 import me.tatocaster.buildnumberoverlaylibrary.exceptions.NumberOverlayException;
+import me.tatocaster.buildnumberoverlaylibrary.utils.Constants;
 import me.tatocaster.buildnumberoverlaylibrary.utils.Validation;
 
 /**
  * Created by tatocaster on 1/28/17.
  */
-
+@SuppressWarnings("unchecked")
 public class NumberOverlay {
     private static final String TAG = NumberOverlay.class.getCanonicalName();
     private static Context applicationContext;
 
     private static final String MULTIPLE_INSTANCE_ERROR_STRING = "Can not initialize multiple times!";
 
-    private static int[] customArray = null;
+    private static HashMap customs = new HashMap<>();
 
     /**
      * instance
@@ -49,8 +52,11 @@ public class NumberOverlay {
     public static synchronized void initialize(Context applicationContext, final int backgroundColor, final int textColor) {
         createInstance(applicationContext);
         Intent intent = getIntent();
-        customArray = new int[] {backgroundColor, textColor};
-        intent.putExtra("customizations", customArray);
+        customs.put(Constants.BACKGROUND_COLOR, backgroundColor);
+        customs.put(Constants.TEXT_COLOR, textColor);
+        customs.put(Constants.CANVAS_HEIGHT, Constants.DEFAULT_CANVAS_HEIGHT);
+        customs.put(Constants.CANVAS_WIDTH, Constants.DEFAULT_CANVAS_WIDTH);
+        intent.putExtra("customizations", customs);
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         getApplicationContext().startActivity(intent);
     }
@@ -58,8 +64,11 @@ public class NumberOverlay {
     public static synchronized void initialize(final int CANVAS_HEIGHT, final int CANVAS_WIDTH, Context applicationContext) {
         createInstance(applicationContext);
         Intent intent = getIntent();
-        customArray = new int[] {CANVAS_HEIGHT, CANVAS_WIDTH};
-        intent.putExtra("customizations", customArray);
+        customs.put(Constants.CANVAS_HEIGHT, CANVAS_HEIGHT);
+        customs.put(Constants.CANVAS_WIDTH, CANVAS_WIDTH);
+        customs.put(Constants.BACKGROUND_COLOR, Constants.DEFAULT_BACKGROUND);
+        customs.put(Constants.TEXT_COLOR, Constants.DEFAULT_TEXT);
+        intent.putExtra("customizations", customs);
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         getApplicationContext().startActivity(intent);
     }
@@ -68,11 +77,15 @@ public class NumberOverlay {
                                                final int CANVAS_HEIGHT, final int CANVAS_WIDTH) {
         createInstance(applicationContext);
         Intent intent = getIntent();
-        customArray = new int[] {backgroundColor, textColor, CANVAS_HEIGHT, CANVAS_WIDTH};
-        intent.putExtra("customizations", customArray);
+        customs.put(Constants.BACKGROUND_COLOR, backgroundColor);
+        customs.put(Constants.TEXT_COLOR, textColor);
+        customs.put(Constants.CANVAS_HEIGHT, CANVAS_HEIGHT);
+        customs.put(Constants.CANVAS_WIDTH, CANVAS_WIDTH);
+        intent.putExtra("customizations", customs);
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         getApplicationContext().startActivity(intent);
     }
+
 
 
 

--- a/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/NumberOverlay.java
+++ b/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/NumberOverlay.java
@@ -16,6 +16,7 @@ public class NumberOverlay {
 
     private static final String MULTIPLE_INSTANCE_ERROR_STRING = "Can not initialize multiple times!";
 
+    private static int[] customArray = null;
 
     /**
      * instance
@@ -32,7 +33,8 @@ public class NumberOverlay {
      *
      * @param applicationContext The application context
      */
-    public static synchronized void initialize(Context applicationContext) {
+
+    public static synchronized void initialize(Context applicationContext, final int backgroundColor, final int textColor) {
         if (instance != null || initialized) {
             throw new NumberOverlayException(MULTIPLE_INSTANCE_ERROR_STRING);
         }
@@ -41,9 +43,12 @@ public class NumberOverlay {
         NumberOverlay.applicationContext = applicationContext;
 
         Intent intent = new Intent(getApplicationContext(), AccessPermissionActivity.class);
+        customArray = new int[] {backgroundColor, textColor}; //0% chance of being null. null cannot be passed to primitives
+        intent.putExtra("customizations", customArray);
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         getApplicationContext().startActivity(intent);
     }
+
 
 
     /**

--- a/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/NumberOverlayView/OverlayView.java
+++ b/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/NumberOverlayView/OverlayView.java
@@ -4,14 +4,17 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.graphics.PixelFormat;
 import android.util.AttributeSet;
+import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
 import android.view.WindowManager;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import me.tatocaster.buildnumberoverlaylibrary.R;
+import me.tatocaster.buildnumberoverlaylibrary.exceptions.OutOfBoundsException;
+import me.tatocaster.buildnumberoverlaylibrary.utils.Constants;
 import me.tatocaster.buildnumberoverlaylibrary.utils.Utils;
-
 /**
  * Created by tatocaster on 1/28/17.
  */
@@ -28,10 +31,10 @@ public class OverlayView extends View {
     private WindowManager mWindowManager;
     private LinearLayout mLinearLayout;
 
-    private static final int CANVAS_WIDTH = 300;
-    private static final int CANVAS_HEIGHT = 150;
-    private int backgroundColor;
-    private int textColor;
+    private int CANVAS_WIDTH = Constants.DEFAULT_CANVAS_WIDTH;
+    private int CANVAS_HEIGHT = Constants.DEFAULT_CANVAS_HEIGHT;
+    private int backgroundColor = Constants.DEFAULT_BACKGROUND;
+    private int textColor = Constants.DEFAULT_TEXT;
     /**
      * main package info
      */
@@ -43,6 +46,12 @@ public class OverlayView extends View {
         init(context);
     }
 
+
+    public OverlayView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init(context);
+    }
+
     public OverlayView(Context context, int backgroundColor, int textColor) {
         super(context);
         init(context);
@@ -50,9 +59,20 @@ public class OverlayView extends View {
         this.textColor = textColor;
     }
 
-    public OverlayView(Context context, AttributeSet attrs) {
-        super(context, attrs);
+    public OverlayView(int CANVAS_HEIGHT, int CANVAS_WIDTH, Context context) {
+        super(context);
         init(context);
+        this.CANVAS_HEIGHT = CANVAS_HEIGHT;
+        this.CANVAS_WIDTH = CANVAS_WIDTH;
+    }
+
+    public OverlayView(Context context, int backgroundColor, int textColor, int CANVAS_HEIGHT, int CANVAS_WIDTH) {
+        super(context);
+        init(context);
+        this.backgroundColor = backgroundColor;
+        this.textColor = textColor;
+        this.CANVAS_HEIGHT = CANVAS_HEIGHT;
+        this.CANVAS_WIDTH = CANVAS_WIDTH;
     }
 
     private void init(Context context) {
@@ -60,12 +80,8 @@ public class OverlayView extends View {
         mPackageInfo = Utils.getVersionInfo(mContext);
     }
 
-   /* public void customize(int backgroundColor, int textColor) {
-        this.backgroundColor = backgroundColor;
-        this.textColor = textColor;
-    } */
 
-    public void addToWindowManager() {
+    public void addToWindowManager() throws OutOfBoundsException {
         WindowManager.LayoutParams windowLayoutParams = new WindowManager.LayoutParams(
                 CANVAS_WIDTH,
                 CANVAS_HEIGHT,
@@ -86,6 +102,20 @@ public class OverlayView extends View {
                         mPackageInfo.versionName,
                         mPackageInfo.versionCode)
         );
+        /*
+        Here is checking. if sum of diff's of both height and width is more than x(e.g. 100, 150, 200..) than set
+        text at some size. There are some dangerous and annoying else/if statements - could be improved(?)
+         */
+        int sumDiff = this.CANVAS_HEIGHT - Constants.DEFAULT_CANVAS_HEIGHT + (this.CANVAS_WIDTH - Constants.DEFAULT_CANVAS_WIDTH);
+        if(sumDiff >= 50 && sumDiff < 100) textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, (int)getResources().getDimension(R.dimen.light)); //test it
+        else if(sumDiff >= 100 && sumDiff < 150) textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, (int)getResources().getDimension(R.dimen.medium));
+        else if(sumDiff >= 150 && sumDiff < 200) textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, (int)getResources().getDimension(R.dimen.a_bit_large));
+        else if(sumDiff == 200) textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, (int)getResources().getDimension(R.dimen.large));
+        else if(sumDiff > 200) {
+            throw new OutOfBoundsException("Cannot increase height/width any more!");
+        }
+       /* float currentTextSize = textView.getTextSize();
+        System.out.println("current text size is " + currentTextSize); */
         mLinearLayout.addView(textView);
     }
 

--- a/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/NumberOverlayView/OverlayView.java
+++ b/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/NumberOverlayView/OverlayView.java
@@ -52,19 +52,7 @@ public class OverlayView extends View {
         init(context);
     }
 
-    public OverlayView(Context context, int backgroundColor, int textColor) {
-        super(context);
-        init(context);
-        this.backgroundColor = backgroundColor;
-        this.textColor = textColor;
-    }
 
-    public OverlayView(int CANVAS_HEIGHT, int CANVAS_WIDTH, Context context) {
-        super(context);
-        init(context);
-        this.CANVAS_HEIGHT = CANVAS_HEIGHT;
-        this.CANVAS_WIDTH = CANVAS_WIDTH;
-    }
 
     public OverlayView(Context context, int backgroundColor, int textColor, int CANVAS_HEIGHT, int CANVAS_WIDTH) {
         super(context);

--- a/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/NumberOverlayView/OverlayView.java
+++ b/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/NumberOverlayView/OverlayView.java
@@ -2,7 +2,6 @@ package me.tatocaster.buildnumberoverlaylibrary.NumberOverlayView;
 
 import android.content.Context;
 import android.content.pm.PackageInfo;
-import android.graphics.Color;
 import android.graphics.PixelFormat;
 import android.util.AttributeSet;
 import android.view.Gravity;
@@ -10,6 +9,7 @@ import android.view.View;
 import android.view.WindowManager;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+
 import me.tatocaster.buildnumberoverlaylibrary.utils.Utils;
 
 /**
@@ -30,6 +30,8 @@ public class OverlayView extends View {
 
     private static final int CANVAS_WIDTH = 300;
     private static final int CANVAS_HEIGHT = 150;
+    private int backgroundColor;
+    private int textColor;
     /**
      * main package info
      */
@@ -39,6 +41,13 @@ public class OverlayView extends View {
     public OverlayView(Context context) {
         super(context);
         init(context);
+    }
+
+    public OverlayView(Context context, int backgroundColor, int textColor) {
+        super(context);
+        init(context);
+        this.backgroundColor = backgroundColor;
+        this.textColor = textColor;
     }
 
     public OverlayView(Context context, AttributeSet attrs) {
@@ -51,6 +60,11 @@ public class OverlayView extends View {
         mPackageInfo = Utils.getVersionInfo(mContext);
     }
 
+   /* public void customize(int backgroundColor, int textColor) {
+        this.backgroundColor = backgroundColor;
+        this.textColor = textColor;
+    } */
+
     public void addToWindowManager() {
         WindowManager.LayoutParams windowLayoutParams = new WindowManager.LayoutParams(
                 CANVAS_WIDTH,
@@ -61,12 +75,12 @@ public class OverlayView extends View {
         windowLayoutParams.gravity = Gravity.BOTTOM | Gravity.END;
 
         mLinearLayout = new LinearLayout(mContext);
-        mLinearLayout.setBackgroundColor(Color.BLACK);
+        mLinearLayout.setBackgroundColor(backgroundColor);
         mWindowManager = (WindowManager) getContext().getSystemService(Context.WINDOW_SERVICE);
         mWindowManager.addView(mLinearLayout, windowLayoutParams);
 
         TextView textView = new TextView(mContext);
-        textView.setTextColor(Color.RED);
+        textView.setTextColor(textColor);
         textView.setText(
                 String.format("Name: %s \n Code: %s",
                         mPackageInfo.versionName,

--- a/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/NumberOverlayView/OverlayView.java
+++ b/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/NumberOverlayView/OverlayView.java
@@ -110,8 +110,8 @@ public class OverlayView extends View {
         if(sumDiff >= 50 && sumDiff < 100) textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, (int)getResources().getDimension(R.dimen.light)); //test it
         else if(sumDiff >= 100 && sumDiff < 150) textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, (int)getResources().getDimension(R.dimen.medium));
         else if(sumDiff >= 150 && sumDiff < 200) textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, (int)getResources().getDimension(R.dimen.a_bit_large));
-        else if(sumDiff == 200) textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, (int)getResources().getDimension(R.dimen.large));
-        else if(sumDiff > 200) {
+        else if(sumDiff >= 200 && sumDiff < 250) textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, (int)getResources().getDimension(R.dimen.large));
+        else if(sumDiff >=250) {
             throw new OutOfBoundsException("Cannot increase height/width any more!");
         }
        /* float currentTextSize = textView.getTextSize();

--- a/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/OverlayService.java
+++ b/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/OverlayService.java
@@ -26,8 +26,14 @@ public class OverlayService extends Service {
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
+        if(intent != null)
+        mOverlayView = new OverlayView(NumberOverlay.getApplicationContext(),
+                intent.getExtras().getIntArray("customizations")[0],
+                intent.getExtras().getIntArray("customizations")[1]);
+      /*  if(intent!= null)
+        mOverlayView.customize(intent.getExtras().getIntArray("customizations")[0],
+                intent.getExtras().getIntArray("customizations")[1]); */
 
-        mOverlayView = new OverlayView(NumberOverlay.getApplicationContext());
         mOverlayView.addToWindowManager();
 
         // this needs to be here, because without the startForeground(), our view will not retain always

--- a/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/OverlayService.java
+++ b/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/OverlayService.java
@@ -7,13 +7,16 @@ import android.os.IBinder;
 import android.support.annotation.Nullable;
 import android.support.v7.app.NotificationCompat;
 
+import java.util.HashMap;
+
 import me.tatocaster.buildnumberoverlaylibrary.NumberOverlayView.OverlayView;
 import me.tatocaster.buildnumberoverlaylibrary.exceptions.OutOfBoundsException;
+import me.tatocaster.buildnumberoverlaylibrary.utils.Constants;
 
 /**
  * Created by tatocaster on 1/28/17.
  */
-
+@SuppressWarnings("unchecked")
 public class OverlayService extends Service {
     private static final String TAG = "OverlayService";
     private static final int FOREGROUND_ID = 9998;
@@ -28,17 +31,12 @@ public class OverlayService extends Service {
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
 
-        if(intent != null) {
-            if (intent.getExtras().getIntArray("customizations").length == 2) //making stuff safe {
-                mOverlayView = new OverlayView(NumberOverlay.getApplicationContext(),
-                        intent.getExtras().getIntArray("customizations")[0],
-                        intent.getExtras().getIntArray("customizations")[1]);
-            else
-                mOverlayView = new OverlayView(NumberOverlay.getApplicationContext(),
-                        intent.getExtras().getIntArray("customizations")[0],
-                        intent.getExtras().getIntArray("customizations")[1],
-                        intent.getExtras().getIntArray("customizations")[2],
-                        intent.getExtras().getIntArray("customizations")[3]);
+
+        if (intent != null) {
+            HashMap<String, Integer> customs = (HashMap<String, Integer>) intent.getExtras().getSerializable("customizations");
+            mOverlayView = new OverlayView(NumberOverlay.getApplicationContext(),
+                    customs.get(Constants.BACKGROUND_COLOR), customs.get(Constants.TEXT_COLOR),
+                    customs.get(Constants.CANVAS_HEIGHT), customs.get(Constants.CANVAS_WIDTH));
 
             try {
                 mOverlayView.addToWindowManager();

--- a/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/OverlayService.java
+++ b/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/OverlayService.java
@@ -17,7 +17,7 @@ import me.tatocaster.buildnumberoverlaylibrary.exceptions.OutOfBoundsException;
 public class OverlayService extends Service {
     private static final String TAG = "OverlayService";
     private static final int FOREGROUND_ID = 9998;
-    private OverlayView mOverlayView;
+    private OverlayView mOverlayView = null;
 
     @Nullable
     @Override
@@ -27,16 +27,24 @@ public class OverlayService extends Service {
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
-        if(intent != null)
-        mOverlayView = new OverlayView(NumberOverlay.getApplicationContext(),
-                intent.getExtras().getIntArray("customizations")[0],
-                intent.getExtras().getIntArray("customizations")[1],
-                340, 203);
-        try {
-            mOverlayView.addToWindowManager();
-        }
-        catch(OutOfBoundsException e) {
-            System.out.println(e.getMessage());
+
+        if(intent != null) {
+            if (intent.getExtras().getIntArray("customizations").length == 2) //making stuff safe {
+                mOverlayView = new OverlayView(NumberOverlay.getApplicationContext(),
+                        intent.getExtras().getIntArray("customizations")[0],
+                        intent.getExtras().getIntArray("customizations")[1]);
+            else
+                mOverlayView = new OverlayView(NumberOverlay.getApplicationContext(),
+                        intent.getExtras().getIntArray("customizations")[0],
+                        intent.getExtras().getIntArray("customizations")[1],
+                        intent.getExtras().getIntArray("customizations")[2],
+                        intent.getExtras().getIntArray("customizations")[3]);
+
+            try {
+                mOverlayView.addToWindowManager();
+            } catch (OutOfBoundsException e) {
+                System.out.println(e.getMessage());
+            }
         }
 
         // this needs to be here, because without the startForeground(), our view will not retain always

--- a/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/OverlayService.java
+++ b/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/OverlayService.java
@@ -8,6 +8,7 @@ import android.support.annotation.Nullable;
 import android.support.v7.app.NotificationCompat;
 
 import me.tatocaster.buildnumberoverlaylibrary.NumberOverlayView.OverlayView;
+import me.tatocaster.buildnumberoverlaylibrary.exceptions.OutOfBoundsException;
 
 /**
  * Created by tatocaster on 1/28/17.
@@ -29,12 +30,14 @@ public class OverlayService extends Service {
         if(intent != null)
         mOverlayView = new OverlayView(NumberOverlay.getApplicationContext(),
                 intent.getExtras().getIntArray("customizations")[0],
-                intent.getExtras().getIntArray("customizations")[1]);
-      /*  if(intent!= null)
-        mOverlayView.customize(intent.getExtras().getIntArray("customizations")[0],
-                intent.getExtras().getIntArray("customizations")[1]); */
-
-        mOverlayView.addToWindowManager();
+                intent.getExtras().getIntArray("customizations")[1],
+                340, 203);
+        try {
+            mOverlayView.addToWindowManager();
+        }
+        catch(OutOfBoundsException e) {
+            System.out.println(e.getMessage());
+        }
 
         // this needs to be here, because without the startForeground(), our view will not retain always
 /*        startForeground(FOREGROUND_ID, createNotification());

--- a/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/exceptions/OutOfBoundsException.java
+++ b/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/exceptions/OutOfBoundsException.java
@@ -1,0 +1,13 @@
+package me.tatocaster.buildnumberoverlaylibrary.exceptions;
+
+
+
+public class OutOfBoundsException extends Exception {
+    public OutOfBoundsException() {
+        super();
+    }
+
+    public OutOfBoundsException(String msg) {
+        super(msg);
+    }
+}

--- a/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/utils/Constants.java
+++ b/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/utils/Constants.java
@@ -8,4 +8,8 @@ public final class Constants {
     public static final int DEFAULT_TEXT = Color.RED;
     public static final int DEFAULT_CANVAS_WIDTH = 300;
     public static final int DEFAULT_CANVAS_HEIGHT = 150;
+    public static final String BACKGROUND_COLOR = "background color";
+    public static final String TEXT_COLOR = "text color";
+    public static final String CANVAS_HEIGHT = "height";
+    public static final String CANVAS_WIDTH = "width";
 }

--- a/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/utils/Constants.java
+++ b/buildnumberoverlaylibrary/src/main/java/me/tatocaster/buildnumberoverlaylibrary/utils/Constants.java
@@ -1,0 +1,11 @@
+package me.tatocaster.buildnumberoverlaylibrary.utils;
+
+
+import android.graphics.Color;
+
+public final class Constants {
+    public static final int DEFAULT_BACKGROUND = Color.BLACK;
+    public static final int DEFAULT_TEXT = Color.RED;
+    public static final int DEFAULT_CANVAS_WIDTH = 300;
+    public static final int DEFAULT_CANVAS_HEIGHT = 150;
+}

--- a/buildnumberoverlaylibrary/src/main/res/values/dimen.xml
+++ b/buildnumberoverlaylibrary/src/main/res/values/dimen.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="def">42px</dimen>
+    <dimen name="light">55px</dimen>
+    <dimen name="medium">65px</dimen>
+    <dimen name="a_bit_large">80px</dimen>
+    <dimen name="large">95px</dimen>
+</resources>

--- a/readme.md
+++ b/readme.md
@@ -26,24 +26,32 @@ supports **minSdk : 11**
 
 <img src="https://raw.githubusercontent.com/tatocaster/BuildNumberOverlay/master/art/art.png" alt="All in one" width="300">
 
-Initialize in your application class
+You can initialize differently in your application class. Here are some examples:
 
 ```java
 NumberOverlay.initialize(this);
 ```
-*demo* : [MyApp.java](https://github.com/tatocaster/BuildNumberOverlay/blob/master/app/src/main/java/me/tatocaster/buildversionoverlay/MyApp.java#L17)
+Only colors:
+```java
+NumberOverlay.initialize(this, Color.GREEN, Color.WHITE);
+```
+Only dimensions:
+```java
+NumberOverlay.initialize(this, 200, 100);
+```
+Both of them:
+```java
+NumberOverlay.initialize(this, Color.GREEN, Color.WHITE, 200, 100);
+```
 
-multiple times init will cause error
+*demo* : [MyApp.java](https://github.com/tatocaster/BuildNumberOverlay/blob/master/app/src/main/java/me/tatocaster/buildversionoverlay/MyApp.java)
+
+multiple times init will cause the error
 `NumberOverlayException` :  
 `"Can not initialize multiple times!"`
 
 `NumberOverlay` class has method `isInitialized()` for advanced logic in your application
  but behind the scenes `initialize()` method uses this.
- 
- ***more to come***
- - change background color
- - change text color
- - change position as user configures
 
 # Quick contributing guide
  - Fork and clone locally


### PR DESCRIPTION
I added the ability to fully customize output window:

- customizing colors and therefore set default dimensions.

- customizing dimensions, width & height and therefore set default colors.

- or customizing both of them.

Behind the scenes:

The code is sending the customization data through app components with `Intent.putExtra` method. Overloaded both `initialize` in _BuildNumberOverlay_ & constructors in _OverlayView_ to process information correctly & powerfully. I also added _dimen.xml_ and stored some custom dimensions in it. And, created _OutOfBoundsException_ to prohibit very large size of the window.

Lastly, I updated some **Usage** stuff in README.